### PR TITLE
fix: trailing slashes in the html params would cause formatting to fail

### DIFF
--- a/__tests__/html-tag.test.ts
+++ b/__tests__/html-tag.test.ts
@@ -10,4 +10,10 @@ describe("html", () => {
       "<div>&lt;script&gt;alert('hello')&lt;/script&gt;</div>"
     );
   });
+
+  it("should escape any trailing backslashes", () => {
+    expect(html`<div>${"<script>alert('hello')</script>\\"}</div>`).toBe(
+      "<div>&lt;script&gt;alert('hello')&lt;/script&gt;\\\\</div>"
+    );
+  });
 });

--- a/src/html-tag.ts
+++ b/src/html-tag.ts
@@ -1,10 +1,11 @@
 /**
- * Creates a html string from the given template literal. Each parameter
- * in the template literal is escaped to not include xml tag characters.
+ * Creates a html string from the given template literal. Each
+ * parameter in the template literal is escaped to not include
+ * xml tag characters.
  *
  * @example
- *  html`<div>${"<span>hello</span>"}</div>`;
- *  // > <div>&lt;span&gt;hello&lt;/span&gt;</div>
+ *   html`<div>${"<span>hello</span>"}</div>`;
+ *   // > <div>&lt;span&gt;hello&lt;/span&gt;</div>
  */
 export function html(...args: any[]): string {
   const b = args[0];
@@ -42,8 +43,31 @@ export function raw(html: string): RawHtml {
   return new RawHtml(html);
 }
 
+function isEscaped(str: string, position: number): boolean {
+  let backslashCount = 0;
+
+  for (let i = position - 1; i >= 0; i--) {
+    if (str[i] === "\\") {
+      backslashCount++;
+    } else {
+      break;
+    }
+  }
+
+  return backslashCount % 2 === 1;
+}
+
 function sanitizeHtml(html: string): string {
-  return html.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const result = html.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  const lastIndex = result.length - 1;
+  if (result[lastIndex] === "\\") {
+    if (!isEscaped(result, lastIndex)) {
+      return result + "\\";
+    }
+  }
+
+  return result;
 }
 
 export function desanitizeHtml(html: string): string {


### PR DESCRIPTION
Fixed a bug that would cause the formatter to fail in rare situations where a backslash was the last character of a string parameter and happened to be right in front of a closing tag (see example below). From now on, the `html` tag literal should escape such characters to prevent this from happening.

```ts
MarkupFormatter.format(html`<span>${"Hello World\\"}</span>`);
// resulting string passed to formatter would look like this:
// <span>Hello World\</span>
// the backslash would cause the xml parser to escape the `<` character
// and the whole thing would be treated as if there's no closing tag

// with the fix, the resulting string will look like this:
// <span>Hello World\\</span>
// since the backslash itself is now escaped, parser will simply ignore it
```