### PR TITLE
feat: normalized how whitespaces are handled in-between text and tags

### DIFF
--- a/__tests__/__setup/jest-setup.js
+++ b/__tests__/__setup/jest-setup.js
@@ -33,15 +33,17 @@ const predefinedBgColors = Object.values(
 
 /** @param {string} value */
 const formatExpectedReceived = (value) =>
-  '"' +
+  "" +
   value
+
     .split("\n")
     .map((line, i) => {
+      line = line.replace(/ /g, Dimmed + String.fromCharCode(183) + unset);
       if (i === 0) return line;
-      return " ".repeat(11) + line;
+      return " ".repeat(10) + line;
     })
     .join("\n") +
-  '"';
+  "";
 
 const customMatchers = {
   /**
@@ -63,11 +65,12 @@ const customMatchers = {
     const displayReceived = formatExpectedReceived(stripped);
 
     return {
-      message: () => `Received string does not match the expected string.
+      message:
+        () => `${Bold}Received string does not match the expected string.${unset}
   
-  Expected: ${displayExpected}
+${green + Bold}Expected:${unset} ${displayExpected}
   
-  Received: ${displayReceived}`,
+${red + Bold}Received:${unset} ${displayReceived}`,
       pass: false,
     };
   },
@@ -81,11 +84,12 @@ const customMatchers = {
 
     if (strStartIndex === -1) {
       return {
-        message: () => `Received string does not contain the expected substring.
+        message:
+          () => `${Bold}Received string does not contain the expected substring.${unset}
   
-  Expected: ${formatExpectedReceived(expected)}
+${green + Bold}Expected:${unset} ${formatExpectedReceived(expected)}
           
-  Received: ${formatExpectedReceived(received)}`,
+${red + Bold}Received:${unset} ${formatExpectedReceived(received)}`,
         pass: false,
       };
     }
@@ -264,7 +268,10 @@ jest.spyOn(MarkupFormatter, "format").mockImplementation((...args) => {
   if (process.env["DISPLAY_RESULTS"] === "true") {
     process.stdout.write(
       `\u001b[1m${expect.getState().currentTestName}:\u001b[0m\n\n` +
-        formatted +
+        formatted
+          .split("\n")
+          .map((line) => line.replace(/ /g, String.fromCharCode(183)))
+          .join("\n") +
         "\n\n"
     );
   }

--- a/__tests__/formatter/__snapshots__/formatter.test.ts.snap
+++ b/__tests__/formatter/__snapshots__/formatter.test.ts.snap
@@ -174,11 +174,11 @@ exports[`MarkupFormatter <ul> tag with <ol> tag nested inside 1`] = `
 
 exports[`MarkupFormatter should correctly format the xml scenario 1 1`] = `
 "[0mHello World
-[0m[31m[1mRed[0m[34m[1m or blue? [0m[31m[1mtext
+[0m[31m[1mRed [0m[34m[1mor blue?[0m[31m[1m text
 [0m[4mThis is one line[0m"
 `;
 
-exports[`MarkupFormatter should correctly format the xml scenario 2 1`] = `"[0m[31mRed[0m[32mGreen[0m[34mBlue[0mNormal[0m"`;
+exports[`MarkupFormatter should correctly format the xml scenario 2 1`] = `"[0m[31mRed[0m [0m[32mGreen[0m [0m[34mBlue[0m Normal[0m"`;
 
 exports[`MarkupFormatter should correctly format the xml scenario 3 1`] = `
 "[0m[31mRed
@@ -187,12 +187,17 @@ exports[`MarkupFormatter should correctly format the xml scenario 3 1`] = `
 [0mNormal[0m"
 `;
 
-exports[`MarkupFormatter should correctly format the xml scenario 4 1`] = `"[0m[31m[1m[3m[4m Red [0m[32m[1m[3m[4m Green [0m"`;
+exports[`MarkupFormatter should correctly format the xml scenario 4 1`] = `"[0m[31m[1m[3m[4m Red [0m[1m[3m[4m [0m[32m[1m[3m[4m Green [0m"`;
 
-exports[`MarkupFormatter should correctly format the xml scenario 5 1`] = `"[0m[33m[1m[5mLorem [0m[34m[1m[5mipsum [0m[32m[1m[2m[5mdolor [0m[32m[1m[2m[5m[7msit [0m[32m[1m[2m[5mamet[0m[34m[1m[5m consectetur [0m[33m[1m[5madipiscing [0m"`;
+exports[`MarkupFormatter should correctly format the xml scenario 5 1`] = `"[0m[33m[1m[4m[5mLorem [0m[34m[1m[4m[5mipsum [0m[32m[1m[2m[4m[5mdolor [0m[32m[1m[2m[4m[5m[7msit [0m[32m[1m[2m[4m[5mamet [0m[34m[1m[4m[5mconsectetur [0m[33m[1m[4m[5madipiscing[0m"`;
 
-exports[`MarkupFormatter should correctly format the xml scenario 6 1`] = `"[0m[38;2;137;245;209mGreen[0m[38;2;245;170;66m [0m[34mBlue[0m[38;2;245;170;66m Orange[0m"`;
+exports[`MarkupFormatter should correctly format the xml scenario 6 1`] = `"[0m[38;2;137;245;209mGreen[0m[38;2;245;170;66m   [0m[34mBlue[0m[38;2;245;170;66m   Orange[0m"`;
 
-exports[`MarkupFormatter should correctly format the xml scenario 7 1`] = `"[0m[33m[4mLorem [0m[34m[9mipsum [0m[32m[2m[9mdolor [0m[34m[9m sit [0m[33m[4mamet[0m"`;
+exports[`MarkupFormatter should correctly format the xml scenario 7 1`] = `"[0m[33m[4mLorem [0m[34m[9mipsum [0m[32m[2m[9mdolor[0m[34m[9m sit[0m[33m[4m amet[0m"`;
 
-exports[`MarkupFormatter should correctly format the xml scenario 8 1`] = `"[0m[33m[1m[[0m[1mHello world[0m[33m[1m][0m"`;
+exports[`MarkupFormatter should correctly format the xml scenario 8 1`] = `"[0m[33m[1m[ [0m[1mHello world[0m[33m[1m ][0m"`;
+
+exports[`MarkupFormatter should correctly format the xml scenario 9 1`] = `
+"[0m[33m[1m[[0m[1mLorem ipsum[0m[33m[1m]
+[[0m[1mdolor sit amet[0m[33m[1m][0m"
+`;

--- a/__tests__/formatter/formatter.test.ts
+++ b/__tests__/formatter/formatter.test.ts
@@ -8,13 +8,13 @@ describe("MarkupFormatter", () => {
         <line>Hello World</line>
         <line bold color="red">
           Red
-          <pre color="blue"> or blue? </pre>
+          <pre color="blue">or blue?</pre>
           text
         </line>
         <line underscore>
           <span>This</span>
-          <pre> is </pre>
-          <pre>one </pre>
+          <pre>is</pre>
+          <pre>one</pre>
           <span>line</span>
         </line>
       `;
@@ -31,11 +31,11 @@ describe("MarkupFormatter", () => {
         color: "red",
         bold: true,
       });
-      expect(formatted).toContainAnsiStringWithStyles(" or blue? ", {
+      expect(formatted).toContainAnsiStringWithStyles("or blue?", {
         color: "blue",
         bold: true,
       });
-      expect(formatted).toContainAnsiStringWithStyles("text", {
+      expect(formatted).toContainAnsiStringWithStyles(" text", {
         color: "red",
         bold: true,
       });
@@ -59,7 +59,7 @@ describe("MarkupFormatter", () => {
 
       const formatted = MarkupFormatter.format(xml);
 
-      expect(formatted).toMatchAnsiString("RedGreenBlueNormal");
+      expect(formatted).toMatchAnsiString("Red Green Blue Normal");
       expect(formatted).toContainAnsiStringWithStyles("Red", {
         color: "red",
       });
@@ -112,7 +112,7 @@ describe("MarkupFormatter", () => {
 
       const formatted = MarkupFormatter.format(xml);
 
-      expect(formatted).toMatchAnsiString(" Red  Green ");
+      expect(formatted).toMatchAnsiString(" Red   Green ");
       expect(formatted).toContainAnsiStringWithStyles(" Red ", {
         color: "red",
         bold: true,
@@ -130,7 +130,7 @@ describe("MarkupFormatter", () => {
 
     it("scenario 5", () => {
       const xml = html`
-        <span blink bold color="yellow">
+        <span join="none" underscore blink bold color="yellow">
           <pre>Lorem </pre>
           <span bold color="blue">
             <pre>ipsum </pre>
@@ -139,18 +139,18 @@ describe("MarkupFormatter", () => {
               <span invert>
                 <pre>sit </pre>
               </span>
-              <pre>amet</pre>
+              <pre>amet </pre>
             </span>
-            <pre> consectetur </pre>
+            <pre>consectetur </pre>
           </span>
-          <pre>adipiscing </pre>
+          <pre>adipiscing</pre>
         </span>
       `;
 
       const formatted = MarkupFormatter.format(xml);
 
       expect(formatted).toMatchAnsiString(
-        "Lorem ipsum dolor sit amet consectetur adipiscing "
+        "Lorem ipsum dolor sit amet consectetur adipiscing"
       );
       expect(formatted).toContainAnsiStringWithStyles("Lorem ", {
         color: "yellow",
@@ -182,14 +182,14 @@ describe("MarkupFormatter", () => {
         dimmed: true,
         inverted: false,
       });
-      expect(formatted).toContainAnsiStringWithStyles(" consectetur ", {
+      expect(formatted).toContainAnsiStringWithStyles("consectetur ", {
         color: "blue",
         bold: true,
         blink: true,
         dimmed: false,
         inverted: false,
       });
-      expect(formatted).toContainAnsiStringWithStyles("adipiscing ", {
+      expect(formatted).toContainAnsiStringWithStyles("adipiscing", {
         color: "yellow",
         bold: true,
         blink: true,
@@ -213,14 +213,14 @@ describe("MarkupFormatter", () => {
 
       const formatted = MarkupFormatter.format(xml);
 
-      expect(formatted).toMatchAnsiString("Green Blue Orange");
+      expect(formatted).toMatchAnsiString("Green   Blue   Orange");
       expect(formatted).toContainAnsiStringWithStyles("Green", {
         color: "rgb(137, 245, 209)",
       });
       expect(formatted).toContainAnsiStringWithStyles("Blue", {
         color: "blue",
       });
-      expect(formatted).toContainAnsiStringWithStyles(" Orange", {
+      expect(formatted).toContainAnsiStringWithStyles("   Orange", {
         color: "#f5aa42",
       });
       expect(formatted).toMatchSnapshot();
@@ -229,13 +229,13 @@ describe("MarkupFormatter", () => {
     it("scenario 7", () => {
       const xml = html`
         <span underscore color="yellow">
-          <pre>Lorem </pre>
+          <pre>Lorem</pre>
           <span no-inherit strike color="blue">
-            <pre>ipsum </pre>
+            <pre>ipsum</pre>
             <span dim color="green">
-              <pre>dolor </pre>
+              <pre>dolor</pre>
             </span>
-            <pre> sit </pre>
+            <pre>sit</pre>
           </span>
           <pre>amet</pre>
         </span>
@@ -243,7 +243,7 @@ describe("MarkupFormatter", () => {
 
       const formatted = MarkupFormatter.format(xml);
 
-      expect(formatted).toMatchAnsiString("Lorem ipsum dolor  sit amet");
+      expect(formatted).toMatchAnsiString("Lorem ipsum dolor sit amet");
       expect(formatted).toContainAnsiStringWithStyles("Lorem ", {
         color: "yellow",
         underscore: true,
@@ -253,19 +253,19 @@ describe("MarkupFormatter", () => {
         strikethrough: true,
         underscore: false,
       });
-      expect(formatted).toContainAnsiStringWithStyles("dolor ", {
+      expect(formatted).toContainAnsiStringWithStyles("dolor", {
         color: "green",
         dimmed: true,
         strikethrough: true,
         underscore: false,
       });
-      expect(formatted).toContainAnsiStringWithStyles(" sit ", {
+      expect(formatted).toContainAnsiStringWithStyles(" sit", {
         color: "blue",
         strikethrough: true,
         underscore: false,
         dimmed: false,
       });
-      expect(formatted).toContainAnsiStringWithStyles("amet", {
+      expect(formatted).toContainAnsiStringWithStyles(" amet", {
         color: "yellow",
         underscore: true,
         strikethrough: false,
@@ -285,8 +285,8 @@ describe("MarkupFormatter", () => {
 
       const formatted = MarkupFormatter.format(xml);
 
-      expect(formatted).toMatchAnsiString("[Hello world]");
-      expect(formatted).toContainAnsiStringWithStyles("[", {
+      expect(formatted).toMatchAnsiString("[ Hello world ]");
+      expect(formatted).toContainAnsiStringWithStyles("[ ", {
         color: "yellow",
         bold: true,
       });
@@ -294,8 +294,38 @@ describe("MarkupFormatter", () => {
         color: "none",
         bold: true,
       });
+      expect(formatted).toContainAnsiStringWithStyles(" ]", {
+        color: "yellow",
+        bold: true,
+      });
+      expect(formatted).toMatchSnapshot();
+    });
+
+    it("scenario 9", () => {
+      const xml = html`
+        <span bold color="yellow">
+          [<span color="none">Lorem ipsum</span>]<br />
+          <span>[</span><span color="none">dolor sit amet</span><span>]</span>
+        </span>
+      `;
+
+      const formatted = MarkupFormatter.format(xml);
+
+      expect(formatted).toMatchAnsiString("[Lorem ipsum]\n[dolor sit amet]");
+      expect(formatted).toContainAnsiStringWithStyles("[", {
+        color: "yellow",
+        bold: true,
+      });
+      expect(formatted).toContainAnsiStringWithStyles("Lorem ipsum", {
+        color: "none",
+        bold: true,
+      });
       expect(formatted).toContainAnsiStringWithStyles("]", {
         color: "yellow",
+        bold: true,
+      });
+      expect(formatted).toContainAnsiStringWithStyles("dolor sit amet", {
+        color: "none",
         bold: true,
       });
       expect(formatted).toMatchSnapshot();
@@ -1516,7 +1546,6 @@ Some text`);
           <line>
             <pad size="2">
               <span>tag 1</span>
-              <s />
               <span>tag 2</span>
             </pad>
           </line>

--- a/src/formatter/scope-tracker.ts
+++ b/src/formatter/scope-tracker.ts
@@ -9,15 +9,14 @@ export type Scope = {
   blink?: boolean;
   dimmed?: boolean;
   inverted?: boolean;
+  join?: "space" | "none";
   noInherit?: boolean;
 };
 
+const DEFAULT_SCOPE: Scope = { tag: "" };
+
 export class ScopeTracker {
-  private static scopeStack: Scope[] = [
-    {
-      tag: "",
-    },
-  ];
+  private static scopeStack: Scope[] = [DEFAULT_SCOPE];
   private static _currentScope: Scope = this.scopeStack[0]!;
 
   static get currentScope(): Scope {


### PR DESCRIPTION
In previous version termx would simply remove any leading and tailing whitespace characters on each text node, this meant that for example if you wanted to have two separate words in different colors next to each other with a whitespace separating those, you'd have to use the `<s />` tag or the `<pre />` tag to insert that whitepsace char.

With this update tags and text nodes should behave more like they do in browsers. If there is any number of new line or space character in between tags and text nodes, exactly one space character will be left there, there's a few exceptions to this rule though, for example when the next tag is a break line tag, whitespaces will be removed.

__Some Examples__
(I've replaced space characters with a `·` to make it easier to read)
```ts
Output.print(html`<span>Hello      <span color="red">World</span></span>`);

// Old output:
// 'HelloWorld'

// New output:
// 'Hello·World'

Output.print(html`
  <line>
    <span>This</span>
    <span>is</span>
    <span>one</span>
    <span>line</span>
  </line>
  <span>This is another</span>
`);

// Old output:
// 'Thisisoneline
//  This·is·another'

// New output:
// 'This·is·one·line
//  This·is·another'
```

Additionally a new attribute has been added `join`, which can be used to use the old behavior. When set to `none`, all leading and tailing whitespace characters will be completely removed, exactly the same as it worked in the previous termx version.