### PR TITLE
fix: too many whitespace characters in between lines of raw text

### DIFF
--- a/__tests__/formatter/__snapshots__/formatter.test.ts.snap
+++ b/__tests__/formatter/__snapshots__/formatter.test.ts.snap
@@ -176,7 +176,7 @@ exports[`MarkupFormatter <pad> tag should correctly add padding for multiline te
 exports[`MarkupFormatter <pad> tag should correctly add padding for multiline text with nested tags 1`] = `
 "[0m   Line 1
    Line 2
-   tag 1   tag 2[0m"
+   tag 1  tag 2[0m"
 `;
 
 exports[`MarkupFormatter <pad> tag should correctly add padding for nested pad tags 1`] = `

--- a/__tests__/formatter/formatter.test.ts
+++ b/__tests__/formatter/formatter.test.ts
@@ -403,6 +403,88 @@ Other text
 `.trim()
       );
     });
+
+    it("scenario 12", () => {
+      const xml = html`
+        <line>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+        </line>
+        <line>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+          auctor, odio at ultricies hendrerit, nisl nunc ultrices tortor, quis
+        </line>
+        <line>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+          auctor, odio at ultricies hendrerit, nisl nunc ultrices tortor, quis
+          ultricies nisl nunc ultrices tortor, quis ultricies nisl nunc ultrices
+        </line>
+        <line>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+          auctor, odio at ultricies hendrerit, nisl nunc ultrices tortor, quis
+          ultricies nisl nunc ultrices tortor, quis ultricies nisl nunc ultrices
+          tortor, quis ultricies nisl nunc ultrices tortor, quis ultricies nisl
+          nunc ultrices tortor, quis ultricies nisl nunc.
+        </line>
+      `;
+
+      const formatted = MarkupFormatter.format(xml);
+
+      expect(formatted).toMatchAnsiString(
+        // First line
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam\n" +
+          // Second line
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam" +
+          " auctor, odio at ultricies hendrerit, nisl nunc ultrices tortor, quis\n" +
+          // Third line
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam" +
+          " auctor, odio at ultricies hendrerit, nisl nunc ultrices tortor, quis" +
+          " ultricies nisl nunc ultrices tortor, quis ultricies nisl nunc ultrices\n" +
+          // Fourth line
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam" +
+          " auctor, odio at ultricies hendrerit, nisl nunc ultrices tortor, quis" +
+          " ultricies nisl nunc ultrices tortor, quis ultricies nisl nunc ultrices" +
+          " tortor, quis ultricies nisl nunc ultrices tortor, quis ultricies nisl" +
+          " nunc ultrices tortor, quis ultricies nisl nunc."
+      );
+    });
+
+    it("scenario 13", () => {
+      const xml = html`
+        <line>
+          <span>One space:|</span>
+          <span>|</span>
+        </line>
+        <line>
+          <span>Two spaces:|</span>
+          <s />
+          <span>|</span>
+        </line>
+        <line>
+          <span>Three spaces:|</span>
+          <s />
+          <s />
+          <span>|</span>
+        </line>
+        <line>
+          <span>Four spaces:|</span>
+          <s />
+          <s />
+          <s />
+          <span>|</span>
+        </line>
+      `;
+
+      const formatted = MarkupFormatter.format(xml);
+
+      expect(formatted).toMatchAnsiString(
+        `
+One space:| |
+Two spaces:|  |
+Three spaces:|   |
+Four spaces:|    |
+      `.trim()
+      );
+    });
   });
 
   describe("<ol> tag", () => {
@@ -1606,7 +1688,7 @@ Some text`);
       const formattedXml = MarkupFormatter.format(xml);
 
       expect(formattedXml).toMatchAnsiString(
-        "   Line 1\n   Line 2\n   tag 1   tag 2"
+        "   Line 1\n   Line 2\n   tag 1  tag 2"
       );
       expect(formattedXml).toMatchSnapshot();
     });

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -144,13 +144,31 @@ export class MarkupFormatter {
     }
   }
 
+  private removeLineBreaks(text: string) {
+    const lines = text.split("\n");
+
+    let result = "";
+
+    if (lines[0]![0] === " " || lines[0]![0] === "\n") {
+      result += " ";
+    }
+
+    for (let i = 0; i < lines.length - 1; i++) {
+      result += lines[i]!.trim() + " ";
+    }
+
+    result += lines[lines.length - 1]!.trim();
+
+    return result;
+  }
+
   private normalizeNode(node: MarkupNode) {
     if (node.tag !== "pre") {
       for (let i = 0; i < node.content.length; i++) {
         const content = node.content[i]!;
 
         if (typeof content === "string") {
-          const singleLined = content.replaceAll("\n", " ");
+          const singleLined = this.removeLineBreaks(content);
           let trimmed = singleLined.trim();
           const prevNodeDisplayType = getNodeDisplayType(node.content[i - 1]);
           const nextNodeDisplayType = getNodeDisplayType(node.content[i + 1]);
@@ -167,7 +185,7 @@ export class MarkupFormatter {
           if (trimmed.length === 0) {
             const shouldKeepWhitespace = !isStartOfLine && !isEndOfLine;
 
-            if (shouldKeepWhitespace) {
+            if (shouldKeepWhitespace && prevTag !== "s") {
               node.content[i] = " ";
             } else {
               // Remove the empty node


### PR DESCRIPTION
1. Fixed a bug which was causing one too many spaces be added to the text where `<s />` was used.
2. Fixed a bug which was causing multiline raw text to get joined with too many white-space characters.

    ### Example
    Input:
    ```html
    <span>
                 Hello
                 World
    </span>
    ```
    Old output:
    ```
    Hello             World
    ```
    New output:
    ```
    Hello World
    ```