### PR TITLE
fix: missing whitespace in the output for text node + whitespace + tag node with text

### DIFF
--- a/__tests__/formatter/__snapshots__/formatter.test.ts.snap
+++ b/__tests__/formatter/__snapshots__/formatter.test.ts.snap
@@ -397,6 +397,8 @@ exports[`MarkupFormatter should correctly format the xml scenario 07 1`] = `"[0
 
 exports[`MarkupFormatter should correctly format the xml scenario 08 1`] = `"[0m[33m[1m[ [0m[1mHello world[0m[33m[1m ][0m"`;
 
+exports[`MarkupFormatter should correctly format the xml scenario 08.1 1`] = `"[0m[33m[1m[[0m[1mHello world[0m[33m[1m][0m"`;
+
 exports[`MarkupFormatter should correctly format the xml scenario 09 1`] = `
 "[0m[33m[1m[[0m[1mLorem ipsum[0m[33m[1m]
 [[0m[1mdolor sit amet[0m[33m[1m][0m"

--- a/__tests__/formatter/formatter.test.ts
+++ b/__tests__/formatter/formatter.test.ts
@@ -278,9 +278,7 @@ describe("MarkupFormatter", () => {
     it("scenario 08", () => {
       const xml = html`
         <span bold color="yellow">
-          [
-          <span color="none"> Hello world </span>
-          ]
+          [ <span color="none"> Hello world </span> ]
         </span>
       `;
 
@@ -296,6 +294,31 @@ describe("MarkupFormatter", () => {
         bold: true,
       });
       expect(formatted).toContainAnsiStringWithStyles(" ]", {
+        color: "yellow",
+        bold: true,
+      });
+      expect(formatted).toMatchSnapshot();
+    });
+
+    it("scenario 08.1", () => {
+      const xml = html`
+        <span bold color="yellow">
+          [<span color="none">Hello world</span>]
+        </span>
+      `;
+
+      const formatted = MarkupFormatter.format(xml);
+
+      expect(formatted).toMatchAnsiString("[Hello world]");
+      expect(formatted).toContainAnsiStringWithStyles("[", {
+        color: "yellow",
+        bold: true,
+      });
+      expect(formatted).toContainAnsiStringWithStyles("Hello world", {
+        color: "none",
+        bold: true,
+      });
+      expect(formatted).toContainAnsiStringWithStyles("]", {
         color: "yellow",
         bold: true,
       });

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -157,7 +157,7 @@ export class MarkupFormatter {
       result += lines[i]!.trim() + " ";
     }
 
-    result += lines[lines.length - 1]!.trim();
+    result += lines[lines.length - 1];
 
     return result;
   }


### PR DESCRIPTION
Previously if a raw text ending with a whitespace was followed with a tag the whitespace between them would get dropped.

Example

Input:
```html
<span> Lorem <span> Ipsum </span></span>
```

Old Output:
```
LoremIpsum
```

New Output:
```
Lorem Ipsum
```